### PR TITLE
Update 20kHz max spec to 100kHz

### DIFF
--- a/docs/module-documentation/waveplayer.md
+++ b/docs/module-documentation/waveplayer.md
@@ -27,7 +27,7 @@ The BpodWavePlayer device is controlled in 2 ways: 
     - A struct containing the connected module's firmware and hardware versions
 - SamplingRate (Hz)
     - 1Hz-10kHz, affects all channels. 
-    - Can be set beyond 10kHz, up to to 20kHz, automatically disabling channels 3-4.
+    - Can be set beyond 10kHz, up to to 100kHz, automatically disabling channels 3-4.
 - OutputRange (String)
     - A string specifying voltage output range for all channels: 
         - '0V:5V'


### PR DESCRIPTION
Analog Output Module can have it's sampling rate set up to 100kHz according to [v1 product page](https://sanworks.io/shop/viewproduct?productID=1013) and [v2 product page](https://sanworks.io/shop/viewproduct?productID=1038).

Product pages state that v1 channels 3 and 4 are disabled past 20kHz, v2 doesn't specify?